### PR TITLE
enable Torch mixin with init args

### DIFF
--- a/src/litmodels/integrations/duplicate.py
+++ b/src/litmodels/integrations/duplicate.py
@@ -31,7 +31,6 @@ def duplicate_hf_model(
 
     if not local_workdir:
         local_workdir = tempfile.mkdtemp()
-        os.makedirs(local_workdir)
     local_workdir = Path(local_workdir)
     model_name = hf_model.replace("/", "_")
 

--- a/src/litmodels/integrations/duplicate.py
+++ b/src/litmodels/integrations/duplicate.py
@@ -31,6 +31,7 @@ def duplicate_hf_model(
 
     if not local_workdir:
         local_workdir = tempfile.mkdtemp()
+        os.makedirs(local_workdir)
     local_workdir = Path(local_workdir)
     model_name = hf_model.replace("/", "_")
 

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -5,7 +5,7 @@ import tempfile
 import warnings
 from abc import ABC
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union, Any
 
 from lightning_utilities.core.rank_zero import rank_zero_warn
 
@@ -41,7 +41,9 @@ class ModelRegistryMixin(ABC):
             temp_folder: The temporary folder to save the model. If None, a default temporary folder is used.
         """
 
-    def _setup(self, name: Optional[str] = None, temp_folder: Union[str, Path, None] = None) -> Tuple[str, str, str]:
+    def _setup(
+        self, name: Optional[str] = None, temp_folder: Union[str, Path, None] = None
+    ) -> Tuple[str, str, Union[str, Path]]:
         """Parse and validate the model name and temporary folder."""
         if name is None:
             name = model_name = self.__class__.__name__
@@ -106,7 +108,7 @@ class PickleRegistryMixin(ModelRegistryMixin):
 class PyTorchRegistryMixin(ModelRegistryMixin):
     """Mixin for PyTorch model registry integration."""
 
-    def __new__(cls, *args, **kwargs) -> "torch.nn.Module":
+    def __new__(cls, *args: Any, **kwargs: Any) -> "torch.nn.Module":
         """Create a new instance of the class without calling __init__."""
         instance = super().__new__(cls)
 

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -1,6 +1,5 @@
 import inspect
 import json
-import os
 import pickle
 import tempfile
 import warnings
@@ -10,7 +9,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 
 from lightning_utilities.core.rank_zero import rank_zero_warn
 
-from litmodels.io.cloud import upload_model_files, download_model_files
+from litmodels.io.cloud import download_model_files, upload_model_files
 
 if TYPE_CHECKING:
     import torch
@@ -132,6 +131,7 @@ class PyTorchRegistryMixin(ModelRegistryMixin):
             temp_folder: The temporary folder to save the model. If None, a default temporary folder is used.
         """
         import torch
+
         # Ensure that the model is in evaluation mode
         if not isinstance(self, torch.nn.Module):
             raise TypeError(f"The model must be a PyTorch `nn.Module` but got: {type(self)}")
@@ -203,7 +203,7 @@ class PyTorchRegistryMixin(ModelRegistryMixin):
             raise RuntimeError(f"Multiple init files found for model: {model_registry} with {init_files}")
         else:
             init_kwargs_path = Path(temp_folder) / init_files[0]
-            with open(init_kwargs_path, "r") as fp:
+            with open(init_kwargs_path) as fp:
                 init_kwargs = json.load(fp)
 
         # Create a new model instance without calling __init__

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -5,7 +5,7 @@ import tempfile
 import warnings
 from abc import ABC
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Tuple, Union, Any
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from lightning_utilities.core.rank_zero import rank_zero_warn
 

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -30,7 +30,9 @@ class ModelRegistryMixin(ABC):
         """
 
     @classmethod
-    def pull_from_registry(cls, name: str, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None) -> object:
+    def pull_from_registry(
+        cls, name: str, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None
+    ) -> object:
         """Pull the model from the registry.
 
         Args:
@@ -74,7 +76,9 @@ class PickleRegistryMixin(ModelRegistryMixin):
         upload_model_files(name=name, path=pickle_path)
 
     @classmethod
-    def pull_from_registry(cls, name: str, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None) -> object:
+    def pull_from_registry(
+        cls, name: str, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None
+    ) -> object:
         """Pull the model from the registry.
 
         Args:

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -103,6 +103,7 @@ class PyTorchRegistryMixin(ModelRegistryMixin):
     """Mixin for PyTorch model registry integration."""
 
     def __new__(cls, *args, **kwargs):
+        """Create a new instance of the class without calling __init__."""
         instance = super().__new__(cls)
 
         # Get __init__ signature excluding 'self'

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -5,7 +5,7 @@ import tempfile
 import warnings
 from abc import ABC
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 from lightning_utilities.core.rank_zero import rank_zero_warn
 
@@ -19,7 +19,7 @@ class ModelRegistryMixin(ABC):
     """Mixin for model registry integration."""
 
     def push_to_registry(
-        self, name: Optional[str] = None, version: Optional[str] = None, temp_folder: Optional[str] = None
+        self, name: Optional[str] = None, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None
     ) -> None:
         """Push the model to the registry.
 
@@ -30,7 +30,7 @@ class ModelRegistryMixin(ABC):
         """
 
     @classmethod
-    def pull_from_registry(cls, name: str, version: Optional[str] = None, temp_folder: Optional[str] = None) -> object:
+    def pull_from_registry(cls, name: str, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None) -> object:
         """Pull the model from the registry.
 
         Args:
@@ -39,7 +39,7 @@ class ModelRegistryMixin(ABC):
             temp_folder: The temporary folder to save the model. If None, a default temporary folder is used.
         """
 
-    def _setup(self, name: Optional[str] = None, temp_folder: Optional[str] = None) -> Tuple[str, str, str]:
+    def _setup(self, name: Optional[str] = None, temp_folder: Union[str, Path, None] = None) -> Tuple[str, str, str]:
         """Parse and validate the model name and temporary folder."""
         if name is None:
             name = model_name = self.__class__.__name__
@@ -56,7 +56,7 @@ class PickleRegistryMixin(ModelRegistryMixin):
     """Mixin for pickle registry integration."""
 
     def push_to_registry(
-        self, name: Optional[str] = None, version: Optional[str] = None, temp_folder: Optional[str] = None
+        self, name: Optional[str] = None, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None
     ) -> None:
         """Push the model to the registry.
 
@@ -74,7 +74,7 @@ class PickleRegistryMixin(ModelRegistryMixin):
         upload_model_files(name=name, path=pickle_path)
 
     @classmethod
-    def pull_from_registry(cls, name: str, version: Optional[str] = None, temp_folder: Optional[str] = None) -> object:
+    def pull_from_registry(cls, name: str, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None) -> object:
         """Pull the model from the registry.
 
         Args:
@@ -122,7 +122,7 @@ class PyTorchRegistryMixin(ModelRegistryMixin):
         return instance
 
     def push_to_registry(
-        self, name: Optional[str] = None, version: Optional[str] = None, temp_folder: Optional[str] = None
+        self, name: Optional[str] = None, version: Optional[str] = None, temp_folder: Union[str, Path, None] = None
     ) -> None:
         """Push the model to the registry.
 
@@ -168,7 +168,7 @@ class PyTorchRegistryMixin(ModelRegistryMixin):
         cls,
         name: str,
         version: Optional[str] = None,
-        temp_folder: Optional[str] = None,
+        temp_folder: Union[str, Path, None] = None,
         torch_load_kwargs: Optional[dict] = None,
     ) -> "torch.nn.Module":
         """Pull the model from the registry.

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -167,6 +167,7 @@ class PyTorchRegistryMixin(ModelRegistryMixin):
         torch.save(self.state_dict(), torch_state_dict_path)
         model_registry = f"{name}:{version}" if version else name
         # todo: consider creating another temp folder and copying these two files
+        # todo: updating SDK to support uploading just specific files
         upload_model_files(name=model_registry, path=temp_folder)
 
     @classmethod

--- a/src/litmodels/integrations/mixins.py
+++ b/src/litmodels/integrations/mixins.py
@@ -102,7 +102,7 @@ class PickleRegistryMixin(ModelRegistryMixin):
 class PyTorchRegistryMixin(ModelRegistryMixin):
     """Mixin for PyTorch model registry integration."""
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs) -> "torch.nn.Module":
         """Create a new instance of the class without calling __init__."""
         instance = super().__new__(cls)
 

--- a/src/litmodels/io/cloud.py
+++ b/src/litmodels/io/cloud.py
@@ -72,7 +72,7 @@ def upload_model_files(
 
 def download_model_files(
     name: str,
-    download_dir: str = ".",
+    download_dir: Union[str, Path] = ".",
     progress_bar: bool = True,
 ) -> Union[str, List[str]]:
     """Download a checkpoint from the model store.

--- a/src/litmodels/io/cloud.py
+++ b/src/litmodels/io/cloud.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from lightning_sdk.lightning_cloud.env import LIGHTNING_CLOUD_URL
@@ -41,7 +42,7 @@ def _print_model_link(name: str, verbose: Union[bool, int]) -> None:
 
 def upload_model_files(
     name: str,
-    path: str,
+    path: Union[str, Path],
     progress_bar: bool = True,
     cloud_account: Optional[str] = None,
     verbose: Union[bool, int] = 1,

--- a/src/litmodels/io/gateway.py
+++ b/src/litmodels/io/gateway.py
@@ -10,7 +10,6 @@ from litmodels.io.cloud import download_model_files, upload_model_files
 
 if module_available("torch"):
     import torch
-    from torch.nn import Module
 else:
     torch = None
 
@@ -20,7 +19,7 @@ if TYPE_CHECKING:
 
 def upload_model(
     name: str,
-    model: Union[str, Path, "Module", Any],
+    model: Union[str, Path, "torch.nn.Module", Any],
     progress_bar: bool = True,
     cloud_account: Optional[str] = None,
     staging_dir: Optional[str] = None,
@@ -42,19 +41,18 @@ def upload_model(
     """
     if not staging_dir:
         staging_dir = tempfile.mkdtemp()
+        os.makedirs(staging_dir)
     # if LightningModule and isinstance(model, LightningModule):
     #     path = os.path.join(staging_dir, f"{model.__class__.__name__}.ckpt")
     #     model.save_checkpoint(path)
     if torch and isinstance(model, torch.jit.ScriptModule):
         path = os.path.join(staging_dir, f"{model.__class__.__name__}.ts")
         model.save(path)
-    elif torch and isinstance(model, Module):
+    elif torch and isinstance(model, torch.nn.Module):
         path = os.path.join(staging_dir, f"{model.__class__.__name__}.pth")
         torch.save(model.state_dict(), path)
-    elif isinstance(model, str):
+    elif isinstance(model, (str, Path)):
         path = model
-    elif isinstance(model, Path):
-        path = str(model)
     else:
         path = os.path.join(staging_dir, f"{model.__class__.__name__}.pkl")
         joblib.dump(model, path)

--- a/src/litmodels/io/gateway.py
+++ b/src/litmodels/io/gateway.py
@@ -41,7 +41,6 @@ def upload_model(
     """
     if not staging_dir:
         staging_dir = tempfile.mkdtemp()
-        os.makedirs(staging_dir)
     # if LightningModule and isinstance(model, LightningModule):
     #     path = os.path.join(staging_dir, f"{model.__class__.__name__}.ckpt")
     #     model.save_checkpoint(path)

--- a/src/litmodels/io/gateway.py
+++ b/src/litmodels/io/gateway.py
@@ -42,7 +42,7 @@ def upload_model(
     if not staging_dir:
         staging_dir = tempfile.mkdtemp()
     if isinstance(model, (str, Path)):
-        path = model  # type: ignore[assignment]
+        path = model
     # if LightningModule and isinstance(model, LightningModule):
     #     path = os.path.join(staging_dir, f"{model.__class__.__name__}.ckpt")
     #     model.save_checkpoint(path)
@@ -106,7 +106,7 @@ def load_model(name: str, download_dir: str = ".") -> Any:
     download_paths = [p for p in download_paths if Path(p).suffix.lower() not in {".md", ".txt", ".rst"}]
     if len(download_paths) > 1:
         raise NotImplementedError("Downloaded model with multiple files is not supported yet.")
-    model_path = Path(os.path.join(download_dir, download_paths[0]))
+    model_path = Path(download_dir) / download_paths[0]
     if model_path.suffix.lower() == ".pkl":
         return joblib.load(model_path)
     if model_path.suffix.lower() == ".ts":

--- a/src/litmodels/io/gateway.py
+++ b/src/litmodels/io/gateway.py
@@ -41,17 +41,17 @@ def upload_model(
     """
     if not staging_dir:
         staging_dir = tempfile.mkdtemp()
+    if isinstance(model, (str, Path)):
+        path = model  # type: ignore[assignment]
     # if LightningModule and isinstance(model, LightningModule):
     #     path = os.path.join(staging_dir, f"{model.__class__.__name__}.ckpt")
     #     model.save_checkpoint(path)
-    if torch and isinstance(model, torch.jit.ScriptModule):
+    elif torch and isinstance(model, torch.jit.ScriptModule):
         path = os.path.join(staging_dir, f"{model.__class__.__name__}.ts")
         model.save(path)
     elif torch and isinstance(model, torch.nn.Module):
         path = os.path.join(staging_dir, f"{model.__class__.__name__}.pth")
         torch.save(model.state_dict(), path)
-    elif isinstance(model, (str, Path)):
-        path = model
     else:
         path = os.path.join(staging_dir, f"{model.__class__.__name__}.pkl")
         joblib.dump(model, path)

--- a/src/litmodels/io/gateway.py
+++ b/src/litmodels/io/gateway.py
@@ -67,7 +67,7 @@ def upload_model(
 
 def download_model(
     name: str,
-    download_dir: str = ".",
+    download_dir: Union[str, Path] = ".",
     progress_bar: bool = True,
 ) -> Union[str, List[str]]:
     """Download a checkpoint from the model store.

--- a/tests/integrations/test_cloud.py
+++ b/tests/integrations/test_cloud.py
@@ -243,9 +243,10 @@ def test_pickle_mixin_push_and_pull():
 
 
 class DummyTorchModel(torch.nn.Module, PyTorchRegistryMixin):
-    def __init__(self, input_size=784):
+    def __init__(self, input_size: int, output_size: int = 10):
+        # PyTorchRegistryMixin.__init__ will capture these arguments
         super().__init__()
-        self.fc = torch.nn.Linear(input_size, 10)
+        self.fc = torch.nn.Linear(input_size, output_size)
 
     def forward(self, x):
         x = x.view(x.size(0), -1)

--- a/tests/integrations/test_cloud.py
+++ b/tests/integrations/test_cloud.py
@@ -242,7 +242,10 @@ def test_pickle_mixin_push_and_pull():
     _cleanup_model(teamspace, model_name, expected_num_versions=1)
 
 
-class DummyTorchModel(torch.nn.Module, PyTorchRegistryMixin):
+# This is a dummy model for PyTorch that uses the PyTorchRegistryMixin.
+# This mixin has to be first in the inheritance order.
+# Otherwise, `PyTorchRegistryMixin.__init__` nee to be called explicitly.
+class DummyTorchModel(PyTorchRegistryMixin, torch.nn.Module):
     def __init__(self, input_size: int, output_size: int = 10):
         # PyTorchRegistryMixin.__init__ will capture these arguments
         super().__init__()

--- a/tests/integrations/test_mixins.py
+++ b/tests/integrations/test_mixins.py
@@ -21,7 +21,7 @@ def test_pickle_push_and_pull(mock_download_model, mock_upload_model, tmp_path):
     dummy.push_to_registry(version="v1", temp_folder=str(tmp_path))
     # The expected registry name is "dummy_model:v1" and the file should be placed in the temp folder.
     expected_path = tmp_path / "DummyModel.pkl"
-    mock_upload_model.assert_called_once_with(name="DummyModel:v1", model=expected_path)
+    mock_upload_model.assert_called_once_with(name="DummyModel:v1", path=expected_path)
 
     # Set the mock to return the full path to the pickle file.
     mock_download_model.return_value = ["DummyModel.pkl"]
@@ -31,7 +31,7 @@ def test_pickle_push_and_pull(mock_download_model, mock_upload_model, tmp_path):
     assert loaded_dummy.value == 42
 
 
-class DummyTorchModel(nn.Module, PyTorchRegistryMixin):
+class DummyTorchModel(PyTorchRegistryMixin, nn.Module):
     def __init__(self, input_size: int, output_size: int = 10):
         # PyTorchRegistryMixin.__init__ will capture these arguments
         super().__init__()
@@ -52,12 +52,15 @@ def test_pytorch_push_and_pull(mock_download_model, mock_upload_model, tmp_path)
     output_before = dummy(input_tensor)
 
     dummy.push_to_registry(temp_folder=str(tmp_path))
-    expected_path = tmp_path / f"{dummy.__class__.__name__}.pth"
-    mock_upload_model.assert_called_once_with(name="DummyTorchModel", model=expected_path)
+    mock_upload_model.assert_called_once_with(name="DummyTorchModel", path=str(tmp_path))
 
-    torch.save(dummy.state_dict(), expected_path)
+    torch_file = f"{dummy.__class__.__name__}.pth"
+    torch.save(dummy.state_dict(), tmp_path / torch_file)
+    json_file = f"{dummy.__class__.__name__}__init_kwargs.json"
+    with open(tmp_path / json_file, "w") as fp:
+        fp.write('{"input_size": 784, "output_size": 10}')
     # Prepare mocking for pull_from_registry.
-    mock_download_model.return_value = [f"{dummy.__class__.__name__}.pth"]
+    mock_download_model.return_value = [torch_file, json_file]
     loaded_dummy = DummyTorchModel.pull_from_registry(name="DummyTorchModel", temp_folder=str(tmp_path))
     loaded_dummy.eval()
     output_after = loaded_dummy(input_tensor)

--- a/tests/integrations/test_mixins.py
+++ b/tests/integrations/test_mixins.py
@@ -13,8 +13,8 @@ class DummyModel(PickleRegistryMixin):
         return isinstance(other, DummyModel) and self.value == other.value
 
 
-@mock.patch("litmodels.integrations.mixins.upload_model")
-@mock.patch("litmodels.integrations.mixins.download_model")
+@mock.patch("litmodels.integrations.mixins.upload_model_files")
+@mock.patch("litmodels.integrations.mixins.download_model_files")
 def test_pickle_push_and_pull(mock_download_model, mock_upload_model, tmp_path):
     # Create an instance of DummyModel and call push_to_registry.
     dummy = DummyModel(42)
@@ -32,17 +32,18 @@ def test_pickle_push_and_pull(mock_download_model, mock_upload_model, tmp_path):
 
 
 class DummyTorchModel(nn.Module, PyTorchRegistryMixin):
-    def __init__(self, input_size=784):
+    def __init__(self, input_size: int, output_size: int = 10):
+        # PyTorchRegistryMixin.__init__ will capture these arguments
         super().__init__()
-        self.fc = nn.Linear(input_size, 10)
+        self.fc = nn.Linear(input_size, output_size)
 
     def forward(self, x):
         x = x.view(x.size(0), -1)
         return self.fc(x)
 
 
-@mock.patch("litmodels.integrations.mixins.upload_model")
-@mock.patch("litmodels.integrations.mixins.download_model")
+@mock.patch("litmodels.integrations.mixins.upload_model_files")
+@mock.patch("litmodels.integrations.mixins.download_model_files")
 def test_pytorch_push_and_pull(mock_download_model, mock_upload_model, tmp_path):
     # Create an instance, push the model and record its forward output.
     dummy = DummyTorchModel(784)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Until now, the model has to have only optional kwargs and could not diverge from

For example, this class could not be instantiated without knowing creation arguments
```py
class DummyTorchModel(PyTorchRegistryMixin, torch.nn.Module):
    def __init__(self, input_size: int, output_size: int = 10):
        # PyTorchRegistryMixin.__init__ will capture these arguments
        super().__init__()
        self.fc = torch.nn.Linear(input_size, output_size)

    def forward(self, x):
        x = x.view(x.size(0), -1)
```
the only other way how to pull this model is Pickle which is not very space-efficient


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
