### PR TITLE
ckpt: use default user's teamspace

### DIFF
--- a/src/litmodels/integrations/checkpoints.py
+++ b/src/litmodels/integrations/checkpoints.py
@@ -61,6 +61,7 @@ class LitModelCheckpointMixin(ABC):
         upload_model(name=self.model_registry, model=filepath)
 
     def default_model_name(self, pl_model: "pl.LightningModule") -> str:
+        """Generate a default model name based on the class name and timestamp."""
         return pl_model.__class__.__name__ + f"_{self._datetime_stamp}"
 
     def _update_model_name(self, pl_model: "pl.LightningModule") -> None:
@@ -87,7 +88,7 @@ class LitModelCheckpointMixin(ABC):
             else:  # try to load default users teamspace
                 ts_names = list(_list_available_teamspaces().keys())
                 if len(ts_names) == 1:
-                    self.model_registry = f"{ts_names[0]}/{default_model_name}"
+                    self.model_registry = f"{ts_names[0]}/{self.model_registry}"
                 else:
                     options = "\n\t".join(ts_names)
                     raise RuntimeError(

--- a/src/litmodels/integrations/checkpoints.py
+++ b/src/litmodels/integrations/checkpoints.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 class LitModelCheckpointMixin(ABC):
     """Mixin class for LitModel checkpoint functionality."""
 
-    _auth: Auth  # preserve the auth object for later use
     _datetime_stamp: str
     model_registry: Optional[str] = None
 
@@ -44,8 +43,7 @@ class LitModelCheckpointMixin(ABC):
         self.model_registry = model_name.strip("/") if model_name else None
 
         try:  # authenticate before anything else starts
-            self._auth = Auth()
-            self._auth.authenticate()
+            Auth().authenticate()
         except Exception:
             raise ConnectionError("Unable to authenticate with Lightning Cloud. Check your credentials.")
 

--- a/src/litmodels/integrations/checkpoints.py
+++ b/src/litmodels/integrations/checkpoints.py
@@ -82,7 +82,7 @@ class LitModelCheckpointMixin(ABC):
             teamspace = _resolve_teamspace(None, None, None)
             if teamspace:
                 # case you use default model name and teamspace determined from env. variables aka running in studio
-                self.model_registry = f"{teamspace.owner}/{teamspace.name}/{self.model_registry}"
+                self.model_registry = f"{teamspace.owner.name}/{teamspace.name}/{self.model_registry}"
             else:  # try to load default users teamspace
                 ts_names = list(_list_available_teamspaces().keys())
                 if len(ts_names) == 1:

--- a/src/litmodels/io/cloud.py
+++ b/src/litmodels/io/cloud.py
@@ -3,7 +3,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union, Dict
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from lightning_sdk.lightning_cloud.env import LIGHTNING_CLOUD_URL
 from lightning_sdk.models import _extend_model_name_with_teamspace, _parse_model_name_and_version

--- a/src/litmodels/io/cloud.py
+++ b/src/litmodels/io/cloud.py
@@ -3,7 +3,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union, Dict
 
 from lightning_sdk.lightning_cloud.env import LIGHTNING_CLOUD_URL
 from lightning_sdk.models import _extend_model_name_with_teamspace, _parse_model_name_and_version
@@ -92,3 +92,26 @@ def download_model_files(
         download_dir=download_dir,
         progress_bar=progress_bar,
     )
+
+
+def _list_available_teamspaces() -> Dict[str, dict]:
+    """List available teamspaces for the authenticated user.
+
+    Returns:
+        Dict with teamspace names as keys and their details as values.
+    """
+    from lightning_sdk.api import OrgApi, UserApi
+    from lightning_sdk.utils import resolve as sdk_resolvers
+
+    org_api = OrgApi()
+    user = sdk_resolvers._get_authed_user()
+    teamspaces = {}
+    for ts in UserApi()._get_all_teamspace_memberships(""):
+        if ts.owner_type == "organization":
+            org = org_api._get_org_by_id(ts.owner_id)
+            teamspaces[f"{org.name}/{ts.name}"] = {"name": ts.name, "org": org.name}
+        elif ts.owner_type == "user":  # todo: check also the name
+            teamspaces[f"{user.name}/{ts.name}"] = {"name": ts.name, "user": user}
+        else:
+            raise RuntimeError(f"Unknown organization type {ts.organization_type}")
+    return teamspaces

--- a/tests/integrations/test_checkpoints.py
+++ b/tests/integrations/test_checkpoints.py
@@ -40,7 +40,7 @@ def test_lightning_checkpoint_callback(
     mock_upload_model.return_value.name = expected_model_registry
     monkeypatch.setattr(
         "lightning_sdk.utils.resolve._resolve_teamspace",
-        mock.MagicMock(return_value=mock.MagicMock(owner=mock.MagicMock(name="my-org"), name="dream-team"))
+        mock.MagicMock(return_value=mock.MagicMock(owner=mock.MagicMock(name="my-org"), name="dream-team")),
     )
 
     trainer = Trainer(

--- a/tests/integrations/test_checkpoints.py
+++ b/tests/integrations/test_checkpoints.py
@@ -54,8 +54,8 @@ def test_lightning_checkpoint_callback(mock_auth, mock_upload_model, monkeypatch
         mock.MagicMock(return_value=expected_boring_model),
     )
     if model_name is None or model_name == "model-in-studio":
-        mock_teamspace = mock.Mock()
-        mock_teamspace.owner = expected_org
+        mock_teamspace = mock.Mock(owner=mock.Mock())
+        mock_teamspace.owner.name = expected_org
         mock_teamspace.name = expected_teamspace
 
         monkeypatch.setattr(

--- a/tests/integrations/test_cloud.py
+++ b/tests/integrations/test_cloud.py
@@ -93,7 +93,10 @@ def test_upload_download_model(in_studio, monkeypatch, tmp_path):
 )
 @pytest.mark.parametrize(
     "in_studio",
-    [False, pytest.param(True, marks=pytest.mark.skipif(platform.system() == "Windows", reason="studio is not Windows"))],
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.skipif(platform.system() == "Windows", reason="studio is not Windows")),
+    ],
 )
 @pytest.mark.cloud()
 def test_lightning_default_checkpointing(importing, in_studio, monkeypatch, tmp_path):

--- a/tests/integrations/test_cloud.py
+++ b/tests/integrations/test_cloud.py
@@ -93,7 +93,7 @@ def test_upload_download_model(in_studio, monkeypatch, tmp_path):
 )
 @pytest.mark.parametrize(
     "in_studio",
-    [False, pytest.param(True, marks=pytest.mark.skipif(platform.system() != "Linux", reason="Studio is just Linux"))],
+    [False, pytest.param(True, marks=pytest.mark.skipif(platform.system() == "Windows", reason="studio is not Windows"))],
 )
 @pytest.mark.cloud()
 def test_lightning_default_checkpointing(importing, in_studio, monkeypatch, tmp_path):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR enhances checkpoint management by allowing users to set only the teamspace while keeping the model name defaulted to the class name with a timestamp. If no teamspace is explicitly provided, the system will first check an environment variable. If that is unset, it will assume the user has only one teamspace and use it automatically. If multiple teamspaces exist, an error will be raised.

This change simplifies the onboarding process for new users by reducing configuration overhead while ensuring checkpoints are correctly stored. It also improves automation and aligns with expected usage patterns, making experiment management more seamless.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
